### PR TITLE
Improved getting actual PHP version for AppVeyor

### DIFF
--- a/appveyor.psm1
+++ b/appveyor.psm1
@@ -180,11 +180,15 @@ Function SetupPhpVersionString {
 		DownloadFile $RemoteUrl $DestinationPath
 	}
 
-	$versions = Get-Content $DestinationPath | Where-Object {
+	$VersionString = Get-Content $DestinationPath | Where-Object {
 		$_ -match "php-($Env:PHP_VER\.\d+)-src"
 	} | ForEach-Object { $matches[1] }
 
-	$Env:PHP_FULL_VER = $versions.Split(' ')[-1]
+	If ($VersionString -NotMatch '\d+\.\d+\.\d+') {
+		Throw "Unable to obtain PHP version string using pattern 'php-($Env:PHP_MINOR\.\d+)-src'"
+	}
+
+	$Env:PHP_FULL_VER = $VersionString
 }
 
 Function Expand-Item7zip {
@@ -258,7 +262,8 @@ Function DownloadFile {
 	$RetryCount = 0
 	$Completed  = $false
 
-	$WebClient = new-object System.Net.WebClient
+	$WebClient = New-Object System.Net.WebClient
+	$WebClient.Headers.Add('User-Agent', 'AppVeyor PowerShell Script')
 
 	While (-not $Completed) {
 		Try {


### PR DESCRIPTION
As I can see the PHP.net team experiences some bandwidth issues for the http://windows.php.net website. Therefore, they decided to block all requests without User-Agent.

> **20/feb/2018**: Hi! We seem to be receiving high volume requests coming from empty user agents. While this shouldn't be an issue, this unfortunately resulted in bandwidth issues on this server causing all downloads to be unavailable. We've therefore decided to temporarily block empty user agents until we upgraded our server bandwidth.
> 
> **03/mar/2018**: We've upgraded the server bandwidth. This is however still not sufficient to handle all empty user agent connections. Please update the user agent in your scripts accordingly or contact us so we can discuss it.
> 
> Thank you for your understanding.