### PR TITLE
Improved build proccess on Travis CI [skip appveyor]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
   # friendsofphp/php-cs-fixer v2.9.3 requires php ^5.6 || >=7.0 <7.3
   # We'll remove this in the future
   - |
-      if [ "${PHP_MAJOR}.${PHP_MINOR}" = "7.3" ]; then
+      if [ "${PHP_MAJOR}.${PHP_MINOR}" = "7.3" ] || [ "${PHP_MAJOR}.${PHP_MINOR}" = "7.4" ]; then
         export DEFAULT_COMPOSER_FLAGS="$DEFAULT_COMPOSER_FLAGS --ignore-platform-reqs"
       fi
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,23 @@
+sudo: false
+
 language: php
 
 php:
-#  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3.0RC1
+  - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
+  - 'master'
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 'master'
 
 addons:
   apt:
     packages:
-      # See: https://github.com/travis-ci/travis-ci/issues/9717
-      - libzip4
+      - lcov
 
 env:
   global:
@@ -32,13 +38,7 @@ branches:
     - master
     - develop
 
-sudo: required
-
-dist: xenial
-
 before_install:
-  - travis_retry sudo apt-get update -y
-  - travis_retry sudo apt-get install -y lcov
   - travis_retry gem install coveralls-lcov
   - export PHP_MAJOR="$(`phpenv which php` -r 'echo phpversion();' | cut -d '.' -f 1)"
   - export PHP_MINOR="$(`phpenv which php` -r 'echo phpversion();' | cut -d '.' -f 2)"


### PR DESCRIPTION
- Add initial support of PHP 7.4 (nightly). Does not work yet
- Use latest available PHP 7.3
- Don't use `sudo` to speed up the builds
- Minor cleaning up