### PR TITLE
Fixed CFLAGS for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
       fi
 install:
   - phpize
-  - ./configure CFLAGS="--coverage -fprofile-arcs -ftest-coverage $CFLAGS" LDFLAGS="--coverage"
+  - ./configure CFLAGS="-fprofile-arcs -ftest-coverage $CFLAGS" LDFLAGS="--coverage"
   - make clean all
 
 before_script:


### PR DESCRIPTION
The `--coverage` is a synonym for `-fprofile-arcs` and `-ftest-coverage` (when compiling) and `-lgcov` (when linking). 

There is two issues:
- `CFLAGS` already contains `-fprofile-arcs -ftest-coverage` 
- clang does not support `--coverage` synonym in the `CFLAGS`

In other hand `--coverage` is correct linker flag (despite the fact that it is a synonym) because clang support it.