### PR TITLE
Fix: skip PSR-18 tests when PHP < 7

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -124,6 +124,9 @@
    <file name="tests/PsrHttpClientNetworkExceptionInterface.phpt" role="test"/>
    <file name="tests/PsrHttpClientRequestExceptionInterface.phpt" role="test"/>
    <file name="tests/SampleClient.inc" role="test"/>
+   <file name="tests/skip.inc" role="test"/>
+   <file name="tests/skip_for_php5.inc" role="test"/>
+   <file name="tests/skip_for_php7.inc" role="test"/>
   </dir>
  </contents>
  <dependencies>

--- a/tests/PsrCacheCacheException.phpt
+++ b/tests/PsrCacheCacheException.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Cache\CacheException
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Cache\CacheException;

--- a/tests/PsrCacheCacheItemInterface.phpt
+++ b/tests/PsrCacheCacheItemInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Cache\CacheItemInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleCacheItem.inc';

--- a/tests/PsrCacheCacheItemPoolInterface.phpt
+++ b/tests/PsrCacheCacheItemPoolInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Cache\CacheItemPoolInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleCacheItem.inc';

--- a/tests/PsrCacheInvalidArgumentException.phpt
+++ b/tests/PsrCacheInvalidArgumentException.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Cache\InvalidArgumentException
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Cache\CacheException;

--- a/tests/PsrContainerContainerExceptionInterface.phpt
+++ b/tests/PsrContainerContainerExceptionInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Container\ContainerExceptionInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Container\ContainerExceptionInterface;

--- a/tests/PsrContainerContainerInterface.phpt
+++ b/tests/PsrContainerContainerInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Container\ContainerInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Container\ContainerInterface;

--- a/tests/PsrContainerNotFoundExceptionInterface.phpt
+++ b/tests/PsrContainerNotFoundExceptionInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Container\NotFoundExceptionInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Container\ContainerExceptionInterface;

--- a/tests/PsrHttpClientClientExceptionInterface.phpt
+++ b/tests/PsrHttpClientClientExceptionInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Client\ClientExceptionInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 use Psr\Http\Client\ClientExceptionInterface;

--- a/tests/PsrHttpClientClientExceptionInterface.phpt
+++ b/tests/PsrHttpClientClientExceptionInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Client\ClientExceptionInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
 --FILE--
 <?php
 use Psr\Http\Client\ClientExceptionInterface;

--- a/tests/PsrHttpClientClientInterface.phpt
+++ b/tests/PsrHttpClientClientInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Client\ClientInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrHttpClientClientInterface.phpt
+++ b/tests/PsrHttpClientClientInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Client\ClientInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrHttpClientNetworkExceptionInterface.phpt
+++ b/tests/PsrHttpClientNetworkExceptionInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Client\NetworkExceptionInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
 --FILE--
 <?php
 use Psr\Http\Message\RequestInterface;

--- a/tests/PsrHttpClientNetworkExceptionInterface.phpt
+++ b/tests/PsrHttpClientNetworkExceptionInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Client\NetworkExceptionInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 use Psr\Http\Message\RequestInterface;

--- a/tests/PsrHttpClientRequestExceptionInterface.phpt
+++ b/tests/PsrHttpClientRequestExceptionInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Client\RequestExceptionInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
 --FILE--
 <?php
 use Psr\Http\Message\RequestInterface;

--- a/tests/PsrHttpClientRequestExceptionInterface.phpt
+++ b/tests/PsrHttpClientRequestExceptionInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Client\RequestExceptionInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 use Psr\Http\Message\RequestInterface;

--- a/tests/PsrHttpMessageMessageInterface.phpt
+++ b/tests/PsrHttpMessageMessageInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\MessageInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrHttpMessageRequestFactoryInterface.phpt
+++ b/tests/PsrHttpMessageRequestFactoryInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\RequestFactoryInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrHttpMessageRequestInterface.phpt
+++ b/tests/PsrHttpMessageRequestInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\RequestInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrHttpMessageResponseFactoryInterface.phpt
+++ b/tests/PsrHttpMessageResponseFactoryInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\ResponseFactoryInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrHttpMessageResponseInterface.phpt
+++ b/tests/PsrHttpMessageResponseInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\ResponseInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrHttpMessageServerRequestFactoryInterface.phpt
+++ b/tests/PsrHttpMessageServerRequestFactoryInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\ServerRequestFactoryInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrHttpMessageServerRequestInterface.phpt
+++ b/tests/PsrHttpMessageServerRequestInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\ServerRequestInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrHttpMessageStreamFactoryInterface.phpt
+++ b/tests/PsrHttpMessageStreamFactoryInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\StreamFactoryInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleStream.inc';

--- a/tests/PsrHttpMessageStreamInterface.phpt
+++ b/tests/PsrHttpMessageStreamInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\StreamInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleStream.inc';

--- a/tests/PsrHttpMessageUploadedFileFactoryInterface.phpt
+++ b/tests/PsrHttpMessageUploadedFileFactoryInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\UploadedFileFactoryInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleStream.inc';

--- a/tests/PsrHttpMessageUploadedFileInterface.phpt
+++ b/tests/PsrHttpMessageUploadedFileInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\UploadedFileInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleUploadedFile.inc';

--- a/tests/PsrHttpMessageUriFactoryInterface.phpt
+++ b/tests/PsrHttpMessageUriFactoryInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\UriFactoryInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleUri.inc';

--- a/tests/PsrHttpMessageUriInterface.phpt
+++ b/tests/PsrHttpMessageUriInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Message\UriInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleUri.inc';

--- a/tests/PsrHttpServerMiddlewareInterface.phpt
+++ b/tests/PsrHttpServerMiddlewareInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Server\MiddlewareInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrHttpServerRequestHandlerInterface.phpt
+++ b/tests/PsrHttpServerRequestHandlerInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Http\Server\RequestHandlerInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleMessage.inc';

--- a/tests/PsrLinkEvolvableLinkInterface.phpt
+++ b/tests/PsrLinkEvolvableLinkInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Link\EvolvableLinkInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Link\LinkInterface;

--- a/tests/PsrLinkEvolvableLinkProviderInterface.phpt
+++ b/tests/PsrLinkEvolvableLinkProviderInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Link\EvolvableLinkProviderInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Link\LinkInterface;

--- a/tests/PsrLinkLinkInterface.phpt
+++ b/tests/PsrLinkLinkInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Link\LinkInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Link\LinkInterface;

--- a/tests/PsrLinkLinkProviderInterface.phpt
+++ b/tests/PsrLinkLinkProviderInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Link\LinkProviderInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Link\LinkProviderInterface;

--- a/tests/PsrLogAbstractLogger.phpt
+++ b/tests/PsrLogAbstractLogger.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Log\AbstractLogger
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleLogger2.inc';

--- a/tests/PsrLogAbstractLogger_construct.phpt
+++ b/tests/PsrLogAbstractLogger_construct.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Log\AbstractLogger
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Log\AbstractLogger;

--- a/tests/PsrLogInvalidArgumentException.phpt
+++ b/tests/PsrLogInvalidArgumentException.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Log\InvalidArgumentException
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Log\InvalidArgumentException;

--- a/tests/PsrLogLevel.phpt
+++ b/tests/PsrLogLevel.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Log\LogLevel
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Log\LogLevel;

--- a/tests/PsrLogLoggerAwareInterface.phpt
+++ b/tests/PsrLogLoggerAwareInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Log\LoggerAwareInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleLogger.inc';

--- a/tests/PsrLogLoggerAwareTrait.phpt
+++ b/tests/PsrLogLoggerAwareTrait.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Log\LoggerAwareTrait
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_VERSION_ID < 50400 ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Log\LoggerAwareTrait;

--- a/tests/PsrLogLoggerInterface.phpt
+++ b/tests/PsrLogLoggerInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Log\LoggerInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleLogger.inc';

--- a/tests/PsrLogLoggerTrait.phpt
+++ b/tests/PsrLogLoggerTrait.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Log\LoggerTrait
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_VERSION_ID < 50400 ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Log\LoggerTrait;

--- a/tests/PsrLogNullLogger.phpt
+++ b/tests/PsrLogNullLogger.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Log\NullLogger
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\Log\NullLogger;

--- a/tests/PsrSimpleCacheCacheException.phpt
+++ b/tests/PsrSimpleCacheCacheException.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\SimpleCache\CacheException
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\SimpleCache\CacheException;

--- a/tests/PsrSimpleCacheCacheInterface.phpt
+++ b/tests/PsrSimpleCacheCacheInterface.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\SimpleCache\CacheInterface
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\SimpleCache\CacheInterface;

--- a/tests/PsrSimpleCacheInvalidArgumentException.phpt
+++ b/tests/PsrSimpleCacheInvalidArgumentException.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\SimpleCache\InvalidArgumentException
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 use Psr\SimpleCache\InvalidArgumentException;

--- a/tests/gh20.phpt
+++ b/tests/gh20.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Psr\Log\AbstractLogger context not array
 --SKIPIF--
-<?php if( !extension_loaded('psr') ) die('skip '); ?>
+<?php include('skip.inc'); ?>
 --FILE--
 <?php
 include __DIR__ . '/SampleLogger2.inc';

--- a/tests/phpinfo.phpt
+++ b/tests/phpinfo.phpt
@@ -1,7 +1,7 @@
 --TEST--
 psr phpinfo
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION < 7 ) die('skip '); ?>
+<?php include('skip_for_php5.inc'); ?>
 --FILE--
 <?php
 phpinfo(INFO_MODULES);

--- a/tests/phpinfo5.phpt
+++ b/tests/phpinfo5.phpt
@@ -1,7 +1,7 @@
 --TEST--
 psr phpinfo
 --SKIPIF--
-<?php if( !extension_loaded('psr') || PHP_MAJOR_VERSION >= 7 ) die('skip '); ?>
+<?php include('skip_for_php7.inc'); ?>
 --FILE--
 <?php
 phpinfo(INFO_MODULES);

--- a/tests/skip.inc
+++ b/tests/skip.inc
@@ -1,0 +1,4 @@
+<?php
+if (!extension_loaded("psr")) {
+    die('skip The psr extension is not loaded');
+}

--- a/tests/skip_for_php5.inc
+++ b/tests/skip_for_php5.inc
@@ -1,0 +1,5 @@
+<?php
+include('skip.inc');
+if (PHP_MAJOR_VERSION < 7) {
+    print "skip Due to version incompatibility";
+}

--- a/tests/skip_for_php7.inc
+++ b/tests/skip_for_php7.inc
@@ -1,0 +1,5 @@
+<?php
+include('skip.inc');
+if (PHP_MAJOR_VERSION >= 7) {
+    print "skip Due to version incompatibility";
+}


### PR DESCRIPTION
fix #54 