### PR TITLE
Fix failure to build on nixpkgs-unstable

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -12,6 +12,7 @@ let
 in
 
 buildPecl rec {
+  pname = "psr";
   name = "psr-${version}";
   version = orDefault phpPsrVersion "v0.6.0";
   src = orDefault phpPsrSrc (fetchurl {


### PR DESCRIPTION
Was broken with: https://github.com/NixOS/nixpkgs/commit/f40f2323fa49a750138caed8d7fc6ba63a84105b#diff-669a86fbeba85981092f7f52d981c148