### PR TITLE
Remove all TSRMLS_CC for PHP 8 compatibility

### DIFF
--- a/php_psr.h
+++ b/php_psr.h
@@ -25,7 +25,7 @@
 #define PHP_PSR_BEGIN_ARG_INFO(c, f, n) ZEND_BEGIN_ARG_INFO_EX(arginfo_ ## c ## _ ## f, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, n)
 #define PHP_PSR_END_ARG_INFO ZEND_END_ARG_INFO
 #define REGISTER_PSR_CLASS_CONST_STRING(ce, const_name, value) \
-        zend_declare_class_constant_stringl(ce, const_name, sizeof(const_name)-1, value, sizeof(value)-1 TSRMLS_CC);
+        zend_declare_class_constant_stringl(ce, const_name, sizeof(const_name)-1, value, sizeof(value)-1);
 
 #ifdef ZEND_ENGINE_3
 #ifdef ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX

--- a/psr_cache.c
+++ b/psr_cache.c
@@ -22,7 +22,7 @@ static zend_always_inline void php_psr_register_CacheException(INIT_FUNC_ARGS)
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Cache\\CacheException", NULL);
-    PsrCacheCacheException_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrCacheCacheException_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} ---------------------------------------------------------------------- */
@@ -44,7 +44,7 @@ static zend_always_inline void php_psr_register_CacheItemInterface(INIT_FUNC_ARG
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Cache\\CacheItemInterface", PsrCacheCacheItemInterface_methods);
-    PsrCacheCacheItemInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrCacheCacheItemInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} ---------------------------------------------------------------------- */
@@ -69,7 +69,7 @@ static zend_always_inline void php_psr_register_CacheItemPoolInterface(INIT_FUNC
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Cache\\CacheItemPoolInterface", PsrCacheCacheItemPoolInterface_methods);
-    PsrCacheCacheItemPoolInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrCacheCacheItemPoolInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} ---------------------------------------------------------------------- */
@@ -81,8 +81,8 @@ static zend_always_inline void php_psr_register_InvalidArgumentException(INIT_FU
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Cache\\InvalidArgumentException", NULL);
-    PsrCacheInvalidArgumentException_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(PsrCacheInvalidArgumentException_ce_ptr TSRMLS_CC, 1, PsrCacheCacheException_ce_ptr);
+    PsrCacheInvalidArgumentException_ce_ptr = zend_register_internal_interface(&ce);
+    zend_class_implements(PsrCacheInvalidArgumentException_ce_ptr, 1, PsrCacheCacheException_ce_ptr);
 }
 
 /* }}} ---------------------------------------------------------------------- */

--- a/psr_container.c
+++ b/psr_container.c
@@ -15,7 +15,7 @@ static zend_always_inline void php_psr_register_PsrContainerContainerExceptionIn
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Container\\ContainerExceptionInterface", NULL);
-    PsrContainerContainerExceptionInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrContainerContainerExceptionInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} ---------------------------------------------------------------------- */
@@ -33,7 +33,7 @@ static zend_always_inline void php_psr_register_PsrContainerContainerInterface(I
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Container\\ContainerInterface", PsrContainerContainerInterface_methods);
-    PsrContainerContainerInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrContainerContainerInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} ---------------------------------------------------------------------- */
@@ -45,8 +45,8 @@ static zend_always_inline void php_psr_register_PsrContainerNotFoundExceptionInt
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Container\\NotFoundExceptionInterface", NULL);
-    PsrContainerNotFoundExceptionInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(PsrContainerNotFoundExceptionInterface_ce_ptr TSRMLS_CC, 1, PsrContainerContainerExceptionInterface_ce_ptr);
+    PsrContainerNotFoundExceptionInterface_ce_ptr = zend_register_internal_interface(&ce);
+    zend_class_implements(PsrContainerNotFoundExceptionInterface_ce_ptr, 1, PsrContainerContainerExceptionInterface_ce_ptr);
 }
 
 /* }}} ---------------------------------------------------------------------- */

--- a/psr_http_client.c
+++ b/psr_http_client.c
@@ -22,7 +22,7 @@ static zend_always_inline void php_psr_register_PsrHttpClientClientInterface(INI
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Client\\ClientInterface", PsrHttpClientClientInterface_methods);
-    PsrHttpClientClientInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpClientClientInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Client\ClientInterface */
@@ -34,7 +34,7 @@ static zend_always_inline void php_psr_register_PsrHttpClientClientExceptionInte
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Client\\ClientExceptionInterface", NULL);
-    PsrHttpClientClientExceptionInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpClientClientExceptionInterface_ce_ptr = zend_register_internal_interface(&ce);
     zend_class_implements(PsrHttpClientClientExceptionInterface_ce_ptr, 1, zend_ce_throwable);
 }
 
@@ -52,8 +52,8 @@ static zend_always_inline void php_psr_register_PsrHttpClientNetworkExceptionInt
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Client\\NetworkExceptionInterface", PsrHttpClientNetworkExceptionInterface_methods);
-    PsrHttpClientNetworkExceptionInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(PsrHttpClientNetworkExceptionInterface_ce_ptr TSRMLS_CC, 1, PsrHttpClientClientExceptionInterface_ce_ptr);
+    PsrHttpClientNetworkExceptionInterface_ce_ptr = zend_register_internal_interface(&ce);
+    zend_class_implements(PsrHttpClientNetworkExceptionInterface_ce_ptr, 1, PsrHttpClientClientExceptionInterface_ce_ptr);
 }
 
 /* }}} Psr\Http\Client\NetworkExceptionInterface */
@@ -70,8 +70,8 @@ static zend_always_inline void php_psr_register_PsrHttpClientRequestExceptionInt
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Client\\RequestExceptionInterface", PsrHttpClientRequestExceptionInterface_methods);
-    PsrHttpClientRequestExceptionInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(PsrHttpClientRequestExceptionInterface_ce_ptr TSRMLS_CC, 1, PsrHttpClientClientExceptionInterface_ce_ptr);
+    PsrHttpClientRequestExceptionInterface_ce_ptr = zend_register_internal_interface(&ce);
+    zend_class_implements(PsrHttpClientRequestExceptionInterface_ce_ptr, 1, PsrHttpClientClientExceptionInterface_ce_ptr);
 }
 
 /* }}} Psr\Http\Client\RequestExceptionInterface */

--- a/psr_http_factory.c
+++ b/psr_http_factory.c
@@ -21,7 +21,7 @@ static zend_always_inline void php_psr_register_PsrHttpMessageRequestFactoryInte
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\RequestFactoryInterface", PsrHttpMessageRequestFactoryInterface_methods);
-    PsrHttpMessageRequestFactoryInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageRequestFactoryInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Message\RequestFactoryInterface */
@@ -38,7 +38,7 @@ static zend_always_inline void php_psr_register_PsrHttpMessageResponseFactoryInt
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\ResponseFactoryInterface", PsrHttpMessageResponseFactoryInterface_methods);
-    PsrHttpMessageResponseFactoryInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageResponseFactoryInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Message\ResponseFactoryInterface */
@@ -55,7 +55,7 @@ static zend_always_inline void php_psr_register_PsrHttpMessageServerRequestFacto
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\ServerRequestFactoryInterface", PsrHttpMessageServerRequestFactoryInterface_methods);
-    PsrHttpMessageServerRequestFactoryInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageServerRequestFactoryInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Message\ServerRequestFactoryInterface */
@@ -74,7 +74,7 @@ static zend_always_inline void php_psr_register_PsrHttpMessageStreamFactoryInter
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\StreamFactoryInterface", PsrHttpMessageStreamFactoryInterface_methods);
-    PsrHttpMessageStreamFactoryInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageStreamFactoryInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Message\StreamFactoryInterface */
@@ -91,7 +91,7 @@ static zend_always_inline void php_psr_register_PsrHttpMessageUploadedFileFactor
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\UploadedFileFactoryInterface", PsrHttpMessageUploadedFileFactoryInterface_methods);
-    PsrHttpMessageUploadedFileFactoryInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageUploadedFileFactoryInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Message\UploadedFileFactoryInterface */
@@ -108,7 +108,7 @@ static zend_always_inline void php_psr_register_PsrHttpMessageUriFactoryInterfac
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\UriFactoryInterface", PsrHttpMessageUriFactoryInterface_methods);
-    PsrHttpMessageUriFactoryInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageUriFactoryInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Message\UriFactoryInterface */

--- a/psr_http_message.c
+++ b/psr_http_message.c
@@ -37,7 +37,7 @@ static zend_always_inline void php_register_PsrHttpMessageMessageInterface(INIT_
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\MessageInterface", PsrHttpMessageMessageInterface_methods);
-    PsrHttpMessageMessageInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageMessageInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Message\MessageInterface */
@@ -59,9 +59,9 @@ static zend_always_inline void php_register_PsrHttpMessageRequestInterface(INIT_
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\RequestInterface", PsrHttpMessageRequestInterface_methods);
-    PsrHttpMessageRequestInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageRequestInterface_ce_ptr = zend_register_internal_interface(&ce);
     // @todo make sure this is right
-    zend_class_implements(PsrHttpMessageRequestInterface_ce_ptr TSRMLS_CC, 1, PsrHttpMessageMessageInterface_ce_ptr);
+    zend_class_implements(PsrHttpMessageRequestInterface_ce_ptr, 1, PsrHttpMessageMessageInterface_ce_ptr);
 }
 
 /* }}} Psr\Http\Message\RequestInterface */
@@ -80,8 +80,8 @@ static zend_always_inline void php_register_PsrHttpMessageResponseInterface(INIT
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\ResponseInterface", PsrHttpMessageResponseInterface_methods);
-    PsrHttpMessageResponseInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(PsrHttpMessageResponseInterface_ce_ptr TSRMLS_CC, 1, PsrHttpMessageMessageInterface_ce_ptr);
+    PsrHttpMessageResponseInterface_ce_ptr = zend_register_internal_interface(&ce);
+    zend_class_implements(PsrHttpMessageResponseInterface_ce_ptr, 1, PsrHttpMessageMessageInterface_ce_ptr);
 }
 
 /* }}} Psr\Http\Message\ResponseInterface */
@@ -110,8 +110,8 @@ static zend_always_inline void php_register_PsrHttpMessageServerRequestInterface
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\ServerRequestInterface", PsrHttpMessageServerRequestInterface_methods);
-    PsrHttpMessageServerRequestInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(PsrHttpMessageServerRequestInterface_ce_ptr TSRMLS_CC, 1, PsrHttpMessageRequestInterface_ce_ptr);
+    PsrHttpMessageServerRequestInterface_ce_ptr = zend_register_internal_interface(&ce);
+    zend_class_implements(PsrHttpMessageServerRequestInterface_ce_ptr, 1, PsrHttpMessageRequestInterface_ce_ptr);
 }
 
 /* }}} Psr\Http\Message\ServerRequestInterface */
@@ -142,7 +142,7 @@ static zend_always_inline void php_register_PsrHttpMessageStreamInterface(INIT_F
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\StreamInterface", PsrHttpMessageStreamInterface_methods);
-    PsrHttpMessageStreamInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageStreamInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Message\StreamInterface */
@@ -164,7 +164,7 @@ static zend_always_inline void php_register_PsrHttpMessageUploadedFileInterface(
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\UploadedFileInterface", PsrHttpMessageUploadedFileInterface_methods);
-    PsrHttpMessageUploadedFileInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageUploadedFileInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Message\UploadedFileInterface */
@@ -196,7 +196,7 @@ static zend_always_inline void php_register_PsrHttpMessageUriInterface(INIT_FUNC
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Message\\UriInterface", PsrHttpMessageUriInterface_methods);
-    PsrHttpMessageUriInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpMessageUriInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Http\Message\UriInterface */

--- a/psr_http_server_handler.c
+++ b/psr_http_server_handler.c
@@ -22,7 +22,7 @@ static zend_always_inline void php_psr_register_PsrHttpServerRequestHandlerInter
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Server\\RequestHandlerInterface", PsrHttpServerRequestHandlerInterface_methods);
-    PsrHttpServerRequestHandlerInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpServerRequestHandlerInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 #endif

--- a/psr_http_server_middleware.c
+++ b/psr_http_server_middleware.c
@@ -22,7 +22,7 @@ static zend_always_inline void php_psr_register_PsrHttpServerMiddlewareInterface
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Http\\Server\\MiddlewareInterface", PsrHttpServerMiddlewareInterface_methods);
-    PsrHttpServerMiddlewareInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrHttpServerMiddlewareInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 #endif

--- a/psr_link.c
+++ b/psr_link.c
@@ -25,8 +25,8 @@ static zend_always_inline void php_psr_register_PsrLinkEvolvableLinkInterface(IN
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Link\\EvolvableLinkInterface", PsrLinkEvolvableLinkInterface_methods);
-    PsrLinkEvolvableLinkInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(PsrLinkEvolvableLinkInterface_ce_ptr TSRMLS_CC, 1, PsrLinkLinkInterface_ce_ptr);
+    PsrLinkEvolvableLinkInterface_ce_ptr = zend_register_internal_interface(&ce);
+    zend_class_implements(PsrLinkEvolvableLinkInterface_ce_ptr, 1, PsrLinkLinkInterface_ce_ptr);
 }
 
 /* }}} ---------------------------------------------------------------------- */
@@ -44,8 +44,8 @@ static zend_always_inline void php_psr_register_PsrLinkEvolvableLinkProviderInte
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Link\\EvolvableLinkProviderInterface", PsrLinkEvolvableLinkProviderInterface_methods);
-    PsrLinkEvolvableLinkProviderInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(PsrLinkEvolvableLinkProviderInterface_ce_ptr TSRMLS_CC, 1, PsrLinkLinkProviderInterface_ce_ptr);
+    PsrLinkEvolvableLinkProviderInterface_ce_ptr = zend_register_internal_interface(&ce);
+    zend_class_implements(PsrLinkEvolvableLinkProviderInterface_ce_ptr, 1, PsrLinkLinkProviderInterface_ce_ptr);
 }
 
 /* }}} ---------------------------------------------------------------------- */
@@ -65,7 +65,7 @@ static zend_always_inline void php_psr_register_PsrLinkLinkInterface(INIT_FUNC_A
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Link\\LinkInterface", PsrLinkLinkInterface_methods);
-    PsrLinkLinkInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrLinkLinkInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} ---------------------------------------------------------------------- */
@@ -83,7 +83,7 @@ static zend_always_inline void php_psr_register_PsrLinkLinkProviderInterface(INI
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Link\\LinkProviderInterface", PsrLinkLinkProviderInterface_methods);
-    PsrLinkLinkProviderInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrLinkLinkProviderInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} ---------------------------------------------------------------------- */

--- a/psr_log.c
+++ b/psr_log.c
@@ -42,7 +42,7 @@ static zend_always_inline void php_psr_register_LogLevel(INIT_FUNC_ARGS)
     zend_class_entry ce;
 
     INIT_CLASS_ENTRY(ce, "Psr\\Log\\LogLevel", NULL);
-    PsrLogLogLevel_ce_ptr = zend_register_internal_class(&ce TSRMLS_CC);
+    PsrLogLogLevel_ce_ptr = zend_register_internal_class(&ce);
 
     REGISTER_PSR_CLASS_CONST_STRING(PsrLogLogLevel_ce_ptr, "EMERGENCY", "emergency");
     REGISTER_PSR_CLASS_CONST_STRING(PsrLogLogLevel_ce_ptr, "ALERT", "alert");
@@ -76,7 +76,7 @@ static zend_function_entry PsrLogLoggerInterface_methods[] = {
 static zend_always_inline void php_psr_register_LoggerInterface(INIT_FUNC_ARGS) {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Log\\LoggerInterface", PsrLogLoggerInterface_methods);
-    PsrLogLoggerInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrLogLoggerInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Log\LoggerInterface */
@@ -93,7 +93,7 @@ static zend_always_inline void php_psr_register_LoggerAwareInterface(INIT_FUNC_A
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Log\\LoggerAwareInterface", PsrLogLoggerAwareInterface_methods);
-    PsrLogLoggerAwareInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrLogLoggerAwareInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} Psr\Log\LoggerAwareInterface */
@@ -109,7 +109,7 @@ static void php_psr_PsrLogAbstractLogger_log(const char * level_str, strsize_t l
     zend_class_entry * expected_ce = NULL; // PsrLogAbstractLogger_ce_ptr
 
 #ifndef FAST_ZPP
-    if( zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Oz|a",
+    if( zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oz|a",
             &_this_zval, expected_ce, &message, &context) == FAILURE) {
         return;
     }
@@ -143,7 +143,7 @@ static void php_psr_PsrLogAbstractLogger_log(const char * level_str, strsize_t l
         array_init(fparams[2]);
     }
 
-    call_user_function(&Z_OBJCE_P(_this_zval)->function_table, &_this_zval, fname, return_value, 3, fparams TSRMLS_CC);
+    call_user_function(&Z_OBJCE_P(_this_zval)->function_table, &_this_zval, fname, return_value, 3, fparams);
 
     zval_ptr_dtor(&fparams[0]);
     zval_ptr_dtor(&fparams[1]);
@@ -165,7 +165,7 @@ static void php_psr_PsrLogAbstractLogger_log(const char * level_str, strsize_t l
         array_init(&fparams[2]);
     }
 
-    call_user_function(&Z_OBJCE_P(_this_zval)->function_table, _this_zval, &fname, return_value, 3, fparams TSRMLS_CC);
+    call_user_function(&Z_OBJCE_P(_this_zval)->function_table, _this_zval, &fname, return_value, 3, fparams);
 
     zval_ptr_dtor(&fparams[0]);
     zval_ptr_dtor(&fparams[2]);
@@ -229,8 +229,8 @@ static zend_always_inline void php_psr_register_AbstractLogger(INIT_FUNC_ARGS)
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Log\\AbstractLogger", PsrLogAbstractLogger_methods);
-    PsrLogAbstractLogger_ce_ptr = zend_register_internal_class(&ce TSRMLS_CC);
-    zend_class_implements(PsrLogAbstractLogger_ce_ptr TSRMLS_CC, 1, PsrLogLoggerInterface_ce_ptr);
+    PsrLogAbstractLogger_ce_ptr = zend_register_internal_class(&ce);
+    zend_class_implements(PsrLogAbstractLogger_ce_ptr, 1, PsrLogLoggerInterface_ce_ptr);
 }
 
 /* }}} Psr\Log\AbstractLogger */
@@ -279,7 +279,7 @@ static zend_always_inline void php_psr_register_LoggerTrait(INIT_FUNC_ARGS)
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Log\\LoggerTrait", PsrLogLoggerTrait_methods);
-    PsrLogLoggerTrait_ce_ptr = zend_register_internal_class(&ce TSRMLS_CC);
+    PsrLogLoggerTrait_ce_ptr = zend_register_internal_class(&ce);
     PsrLogLoggerTrait_ce_ptr->ce_flags |= ZEND_ACC_TRAIT;
 }
 
@@ -298,7 +298,7 @@ PHP_METHOD(PsrLogLoggerAwareTrait, setLogger)
     zval * logger;
 
 #ifndef FAST_ZPP
-    if( zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "OO",
+    if( zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OO",
             &_this_zval, NULL, &logger, PsrLogLoggerInterface_ce_ptr) == FAILURE) {
         return;
     }
@@ -309,7 +309,7 @@ PHP_METHOD(PsrLogLoggerAwareTrait, setLogger)
 	ZEND_PARSE_PARAMETERS_END();
 #endif
 
-    zend_update_property(Z_OBJCE_P(_this_zval), _this_zval, "logger", sizeof("logger")-1, logger TSRMLS_CC);
+    zend_update_property(Z_OBJCE_P(_this_zval), _this_zval, "logger", sizeof("logger")-1, logger);
 }
 
 static zend_function_entry PsrLogLoggerAwareTrait_methods[] = {
@@ -322,9 +322,9 @@ static zend_always_inline void php_psr_register_LoggerAwareTrait(INIT_FUNC_ARGS)
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\Log\\LoggerAwareTrait", PsrLogLoggerAwareTrait_methods);
     //ce.ce_flags |= ZEND_ACC_TRAIT;
-    PsrLogLoggerAwareTrait_ce_ptr = zend_register_internal_class(&ce TSRMLS_CC);
+    PsrLogLoggerAwareTrait_ce_ptr = zend_register_internal_class(&ce);
     PsrLogLoggerAwareTrait_ce_ptr->ce_flags |= ZEND_ACC_TRAIT;
-    zend_declare_property_null(PsrLogLoggerAwareTrait_ce_ptr, "logger", sizeof("logger")-1, ZEND_ACC_PROTECTED TSRMLS_CC);
+    zend_declare_property_null(PsrLogLoggerAwareTrait_ce_ptr, "logger", sizeof("logger")-1, ZEND_ACC_PROTECTED);
 }
 
 #endif

--- a/psr_simple_cache.c
+++ b/psr_simple_cache.c
@@ -22,7 +22,7 @@ static zend_always_inline void php_psr_register_PsrSimpleCacheCacheException(INI
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\SimpleCache\\CacheException", NULL);
-    PsrSimpleCacheCacheException_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrSimpleCacheCacheException_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} ---------------------------------------------------------------------- */
@@ -46,7 +46,7 @@ static zend_always_inline void php_psr_register_PsrSimpleCacheCacheInterface(INI
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\SimpleCache\\CacheInterface", PsrSimpleCacheCacheInterface_methods);
-    PsrSimpleCacheCacheInterface_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
+    PsrSimpleCacheCacheInterface_ce_ptr = zend_register_internal_interface(&ce);
 }
 
 /* }}} ---------------------------------------------------------------------- */
@@ -58,8 +58,8 @@ static zend_always_inline void php_psr_register_PsrSimpleCacheInvalidArgumentExc
 {
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Psr\\SimpleCache\\InvalidArgumentException", NULL);
-    PsrSimpleCacheInvalidArgumentException_ce_ptr = zend_register_internal_interface(&ce TSRMLS_CC);
-    zend_class_implements(PsrSimpleCacheInvalidArgumentException_ce_ptr TSRMLS_CC, 1, PsrSimpleCacheCacheException_ce_ptr);
+    PsrSimpleCacheInvalidArgumentException_ce_ptr = zend_register_internal_interface(&ce);
+    zend_class_implements(PsrSimpleCacheInvalidArgumentException_ce_ptr, 1, PsrSimpleCacheCacheException_ce_ptr);
 }
 
 /* }}} ---------------------------------------------------------------------- */


### PR DESCRIPTION
The psr extension does not compile on the current php master (8.0) due to the removal of TSRMLS_CC.
- [Official announcement](https://github.com/php/php-src/blob/master/UPGRADING.INTERNALS)
- Examples of removal from the php team [here](https://github.com/php/php-src/commit/e05d230e5265e6041e123659daf7c965132f935f), [there](https://github.com/php/php-src/commit/a1fd706d7d3112be71094a28527e6eebeb3a277a) and [over there](https://github.com/php/php-src/commit/9977bdf9b3bd235899c980edda12315ad6fa1338)

Note that this will break PHP 5.6 compatibility (see [the travis](https://travis-ci.org/Antoine87/php-psr)) but i don't think you should care, see below :

![1](https://user-images.githubusercontent.com/21277377/58128784-b177f980-7c18-11e9-9083-a7a52ca221ab.png)


![Untitled](https://user-images.githubusercontent.com/21277377/58128408-da4bbf00-7c17-11e9-8edd-03ba83b514d2.png)
