### PR TITLE
Add PSR-14 support

### DIFF
--- a/.ci/travis_php.sh
+++ b/.ci/travis_php.sh
@@ -10,12 +10,11 @@ export DISPATCH_VERSION=2.0.0
 export REQUEST_HANDLER_VERSION=v1.3.0
 export HTTP_FACTORY_GUZZLE_VERSION=1.0.0
 export HTTP_GUZZLE_PSR18_ADAPTER_VERSION=v1.0.1
+export TUKIO_VERSION=1.0.0
 
 export COVERAGE=${COVERAGE:-true}
 
-export PHP_MAJOR=$(php -r 'echo phpversion();' | cut -d '.' -f 1)
-export PHP_MINOR=$(php -r 'echo phpversion();' | cut -d '.' -f 2)
-export PHP_MAJOR_MINOR="${PHP_MAJOR}.${PHP_MINOR}"
+export PHP_VERSION_ID=$(php -r 'echo PHP_VERSION_ID;')
 
 export PHP_WITH_EXT="`which php` -d extension=`pwd`/modules/psr.so"
 
@@ -23,7 +22,7 @@ export DEFAULT_COMPOSER_FLAGS="--no-interaction --no-ansi --no-progress --no-sug
 
 # friendsofphp/php-cs-fixer v2.9.3 requires php ^5.6 || >=7.0 <7.3
 # We'll remove this in the future
-if [[ "${PHP_MAJOR_MINOR}" = "7.3" ]] || [[ "${PHP_MAJOR_MINOR}" = "7.4" ]] || [[ "${PHP_MAJOR_MINOR}" = "8.0" ]]; then
+if [[ ${PHP_VERSION_ID} -ge 70300 ]]; then
     export DEFAULT_COMPOSER_FLAGS="${DEFAULT_COMPOSER_FLAGS} --ignore-platform-reqs"
 fi
 
@@ -78,6 +77,9 @@ function before_install() (
     init_repository request-handler ${REQUEST_HANDLER_VERSION} https://github.com/middlewares/request-handler.git
     init_repository http-factory-guzzle ${HTTP_FACTORY_GUZZLE_VERSION} https://github.com/http-interop/http-factory-guzzle.git
     init_repository guzzle-psr18-adapter ${HTTP_GUZZLE_PSR18_ADAPTER_VERSION} https://github.com/ricardofiorani/guzzle-psr18-adapter.git
+    if [[ ${PHP_VERSION_ID} -ge 70200 ]]; then
+        init_repository tukio ${TUKIO_VERSION} https://github.com/Crell/Tukio.git
+    fi
 )
 
 function install() (
@@ -119,6 +121,9 @@ function script() (
     test_repository request-handler
     test_repository http-factory-guzzle
     test_repository guzzle-psr18-adapter
+    if [[ ${PHP_VERSION_ID} -ge 70200 ]]; then
+        test_repository tukio
+    fi
 )
 
 function after_success() (

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Added
 - Preliminary PHP 8 (master) support
+- PSR-14 Event Dispatcher support
 
 ### Removed
 - PHP 5 support

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You can use interfaces provided by this extension in another extension easily - 
 | [PSR-7][:psr-7:] | [psr/http-message][:psr-http-message:] | [guzzle/psr7][:guzzle:] |
 | [PSR-11][:psr-11:] | [psr/container][:psr-container:] | [league/container][:league-container:] |
 | [PSR-13][:psr-13:] | [psr/link][:psr-link:] | [php-fig/link-util][:link-util:] |
+| [PSR-14][:psr-14:] | [psr/event-dispatcher][:psr-event-dispatcher:] | [tukio][:tukio:] |
 | [PSR-15][:psr-15:] | [psr/http-server-handler][:psr-http-server-handler:] | [equip/dispatch][:dispatch:] |
 | [PSR-15][:psr-15:] | [psr/http-server-middleware][:psr-http-server-middleware:] | [middleware/request-handler][:request-handler:] |
 | [PSR-16][:psr-16:] | [psr/simple-cache][:psr-simple-cache:] | [psx-cache][:psx-cache:] |
@@ -117,6 +118,7 @@ In your project, you can prevent the installation of the unnecessary composer pa
         "psr/http-message": "^1",
         "psr/container": "^1",
         "psr/link": "^1",
+        "psr/event-dispatcher": "^1",
         "psr/http-server-handler": "^1",
         "psr/http-server-middleware": "^1",
         "psr/simple-cache": "^1",
@@ -131,7 +133,7 @@ This will use this PHP extension instead of downloading from packagist.
 ## Credits
 
 * [@sergeyklay][:github-sergeyklay:] - Appveyor and documentation improvements
-* [@flyinghail][:github-flyinghail:] - PSR-15, PSR-17, and PSR-18 support
+* [@flyinghail][:github-flyinghail:] - PSR-14, PSR-15, PSR-17, and PSR-18 support
 * [@Jan-E][:github-jan-e:] - Original appveyor template
 
 ## License
@@ -186,3 +188,6 @@ PSR Interfaces: Copyright (c) 2012-present [PHP Framework Interoperability Group
 [:psr-18:]: https://www.php-fig.org/psr/psr-18
 [:psr-http-client:]: https://github.com/php-fig/http-client
 [:guzzle-psr18-adapter:]: https://github.com/ricardofiorani/guzzle-psr18-adapter
+[:psr-14:]: http://www.php-fig.org/psr/psr-14
+[:psr-event-dispatcher:]: https://github.com/php-fig/event-dispatcher
+[:tukio:]: https://github.com/Crell/Tukio.git

--- a/config.m4
+++ b/config.m4
@@ -7,6 +7,6 @@ PHP_ARG_ENABLE(psr, whether to enable psr support,
 dnl MAIN -------------------------------------------------------------------------
 if test "$PHP_PSR" != "no"; then
     AC_DEFINE(HAVE_PSR, 1, [Whether you have PSR])
-    PHP_NEW_EXTENSION(psr, php_psr.c psr_cache.c psr_container.c psr_http_message.c psr_link.c psr_log.c psr_simple_cache.c psr_http_server_handler.c psr_http_server_middleware.c psr_http_factory.c psr_http_client.c, $ext_shared)
-    PHP_INSTALL_HEADERS([ext/psr], [php_psr.h psr_cache.h psr_container.h psr_http_message.h psr_link.h psr_log.h psr_simple_cache.h psr_http_server_handler.h psr_http_server_middleware.h psr_http_factory.h psr_http_client.h])
+    PHP_NEW_EXTENSION(psr, php_psr.c psr_cache.c psr_container.c psr_http_message.c psr_link.c psr_log.c psr_simple_cache.c psr_http_server_handler.c psr_http_server_middleware.c psr_http_factory.c psr_http_client.c psr_event_dispatcher.c, $ext_shared)
+    PHP_INSTALL_HEADERS([ext/psr], [php_psr.h psr_cache.h psr_container.h psr_http_message.h psr_link.h psr_log.h psr_simple_cache.h psr_http_server_handler.h psr_http_server_middleware.h psr_http_factory.h psr_http_client.h psr_event_dispatcher.h])
 fi

--- a/config.w32
+++ b/config.w32
@@ -4,6 +4,6 @@ ARG_ENABLE("psr", "Enable psr support", "no");
 
 if (PHP_PSR != "no") {
     AC_DEFINE("HAVE_PSR", 1, "Have PSR Support");
-    EXTENSION("psr", "php_psr.c psr_cache.c psr_container.c psr_http_message.c psr_link.c psr_log.c psr_simple_cache.c psr_http_server_handler.c psr_http_server_middleware.c psr_http_factory.c psr_http_client.c");
-    PHP_INSTALL_HEADERS("ext\\psr", "php_psr.h psr_cache.h psr_container.h psr_http_message.h psr_link.h psr_log.h psr_simple_cache.h psr_http_server_handler.h psr_http_server_middleware.h psr_http_factory.h psr_http_client.h")
+    EXTENSION("psr", "php_psr.c psr_cache.c psr_container.c psr_http_message.c psr_link.c psr_log.c psr_simple_cache.c psr_http_server_handler.c psr_http_server_middleware.c psr_http_factory.c psr_http_client.c psr_event_dispatcher.c");
+    PHP_INSTALL_HEADERS("ext\\psr", "php_psr.h psr_cache.h psr_container.h psr_http_message.h psr_link.h psr_log.h psr_simple_cache.h psr_http_server_handler.h psr_http_server_middleware.h psr_http_factory.h psr_http_client.h psr_event_dispatcher.h")
 }

--- a/package.xml
+++ b/package.xml
@@ -41,6 +41,8 @@
    <file name="psr_cache.h" role="src"/>
    <file name="psr_container.c" role="src"/>
    <file name="psr_container.h" role="src"/>
+   <file name="psr_event_dispatcher.c" role="src"/>
+   <file name="psr_event_dispatcher.h" role="src"/>
    <file name="psr_http_client.c" role="src"/>
    <file name="psr_http_client.h" role="src"/>
    <file name="psr_http_factory.c" role="src"/>
@@ -122,6 +124,14 @@
    <file name="tests/PsrHttpClientRequestExceptionInterface.phpt" role="test"/>
    <file name="tests/SampleClient.inc" role="test"/>
    <file name="tests/skip.inc" role="test"/>
+   <file name="tests/skip_lt_php72.inc" role="test"/>
+   <file name="tests/phpinfo_lt_php72.phpt" role="test"/>
+   <file name="tests/PsrEventDispatcherEventDispatcherInterface.phpt" role="test"/>
+   <file name="tests/PsrEventDispatcherListenerProviderInterface.phpt" role="test"/>
+   <file name="tests/PsrEventDispatcherStoppableEventInterface.phpt" role="test"/>
+   <file name="tests/SampleEventDispatcher.inc" role="test"/>
+   <file name="tests/SampleListenerProvider.inc" role="test"/>
+   <file name="tests/SampleStoppableEvent.inc" role="test"/>
   </dir>
  </contents>
  <dependencies>

--- a/php_psr.c
+++ b/php_psr.c
@@ -21,6 +21,7 @@
 #include "psr_http_server_middleware.h"
 #include "psr_http_factory.h"
 #include "psr_http_client.h"
+#include "psr_event_dispatcher.h"
 
 static PHP_MINIT_FUNCTION(psr)
 {
@@ -34,6 +35,9 @@ static PHP_MINIT_FUNCTION(psr)
     PHP_MINIT(psr_http_server_middleware)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(psr_http_factory)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(psr_http_client)(INIT_FUNC_ARGS_PASSTHRU);
+#if PHP_VERSION_ID >= 70200
+    PHP_MINIT(psr_event_dispatcher)(INIT_FUNC_ARGS_PASSTHRU);
+#endif
     return SUCCESS;
 }
 
@@ -48,6 +52,9 @@ static PHP_MINFO_FUNCTION(psr)
     php_info_print_table_row(2, "PSR-7 Http Message Version", PHP_PSR_HTTP_MESSAGE_VERSION);
     php_info_print_table_row(2, "PSR-11 Container Version", PHP_PSR_CONTAINER_VERSION);
     php_info_print_table_row(2, "PSR-13 Link Version", PHP_PSR_LOG_VERSION);
+#if PHP_VERSION_ID >= 70200
+    php_info_print_table_row(2, "PSR-14 Event Dispatcher", PHP_PSR_EVENT_DISPATCHER_VERSION);
+#endif
     php_info_print_table_row(2, "PSR-15 HTTP Handlers (Server Handler)", PHP_PSR_HTTP_SERVER_HANDLER_VERSION);
     php_info_print_table_row(2, "PSR-15 HTTP Handlers (Middleware)", PHP_PSR_HTTP_SERVER_MIDDLEWARE_VERSION);
     php_info_print_table_row(2, "PSR-16 Simple Cache Version", PHP_PSR_SIMPLE_CACHE_VERSION);

--- a/psr_event_dispatcher.c
+++ b/psr_event_dispatcher.c
@@ -1,0 +1,84 @@
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_psr.h"
+#include "psr_event_dispatcher.h"
+
+#if PHP_VERSION_ID >= 70200
+/* {{{ Psr\EventDispatcher\EventDispatcherInterface */
+
+PHP_PSR_API zend_class_entry * PsrEventDispatcherEventDispatcherInterface_ce_ptr;
+
+static zend_function_entry PsrEventDispatcherEventDispatcherInterface_methods[] = {
+    PHP_PSR_ABSTRACT_ME(PsrEventDispatcherEventDispatcherInterface, dispatch)
+    PHP_FE_END
+};
+
+static zend_always_inline void php_psr_register_PsrEventDispatcherEventDispatcherInterface(INIT_FUNC_ARGS)
+{
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "Psr\\EventDispatcher\\EventDispatcherInterface", PsrEventDispatcherEventDispatcherInterface_methods);
+    PsrEventDispatcherEventDispatcherInterface_ce_ptr = zend_register_internal_interface(&ce);
+}
+
+/* }}} Psr\EventDispatcher\EventDispatcherInterface */
+/* {{{ Psr\EventDispatcher\ListenerProviderInterface */
+
+PHP_PSR_API zend_class_entry * PsrEventDispatcherListenerProviderInterface_ce_ptr;
+
+static zend_function_entry PsrEventDispatcherListenerProviderInterface_methods[] = {
+    PHP_PSR_ABSTRACT_ME(PsrEventDispatcherListenerProviderInterface, getListenersForEvent)
+    PHP_FE_END
+};
+
+static zend_always_inline void php_psr_register_PsrEventDispatcherListenerProviderInterface(INIT_FUNC_ARGS)
+{
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "Psr\\EventDispatcher\\ListenerProviderInterface", PsrEventDispatcherListenerProviderInterface_methods);
+    PsrEventDispatcherListenerProviderInterface_ce_ptr = zend_register_internal_interface(&ce);
+}
+
+/* }}} Psr\EventDispatcher\ListenerProviderInterface */
+/* {{{ Psr\EventDispatcher\StoppableEventInterface */
+
+PHP_PSR_API zend_class_entry * PsrEventDispatcherStoppableEventInterface_ce_ptr;
+
+static zend_function_entry PsrEventDispatcherStoppableEventInterface_methods[] = {
+    PHP_PSR_ABSTRACT_ME(PsrEventDispatcherStoppableEventInterface, isPropagationStopped)
+    PHP_FE_END
+};
+
+static zend_always_inline void php_psr_register_PsrEventDispatcherStoppableEventInterface(INIT_FUNC_ARGS)
+{
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "Psr\\EventDispatcher\\StoppableEventInterface", PsrEventDispatcherStoppableEventInterface_methods);
+    PsrEventDispatcherStoppableEventInterface_ce_ptr = zend_register_internal_interface(&ce);
+}
+
+/* }}} Psr\EventDispatcher\StoppableEventInterface */
+#endif
+
+/* {{{ PHP_MINIT_FUNCTION */
+PHP_MINIT_FUNCTION(psr_event_dispatcher)
+{
+#if PHP_VERSION_ID >= 70200
+    php_psr_register_PsrEventDispatcherEventDispatcherInterface(INIT_FUNC_ARGS_PASSTHRU);
+    php_psr_register_PsrEventDispatcherListenerProviderInterface(INIT_FUNC_ARGS_PASSTHRU);
+    php_psr_register_PsrEventDispatcherStoppableEventInterface(INIT_FUNC_ARGS_PASSTHRU);
+#endif
+
+    return SUCCESS;
+}
+/* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: fdm=marker
+ * vim: et sw=4 ts=4
+ */

--- a/psr_event_dispatcher.h
+++ b/psr_event_dispatcher.h
@@ -1,0 +1,38 @@
+
+#ifndef PSR_EVENT_DISPATCHER_H
+#define PSR_EVENT_DISPATCHER_H
+
+#include "php.h"
+#include "php_psr.h"
+
+#if PHP_VERSION_ID >= 70200
+#define PHP_PSR_EVENT_DISPATCHER_VERSION "1.0.0"
+
+extern PHP_PSR_API zend_class_entry * PsrEventDispatcherEventDispatcherInterface_ce_ptr;
+extern PHP_PSR_API zend_class_entry * PsrEventDispatcherListenerProviderInterface_ce_ptr;
+extern PHP_PSR_API zend_class_entry * PsrEventDispatcherStoppableEventInterface_ce_ptr;
+
+extern PHP_MINIT_FUNCTION(psr_event_dispatcher);
+
+PHP_PSR_BEGIN_ARG_INFO(PsrEventDispatcherEventDispatcherInterface, dispatch, 1)
+    ZEND_ARG_TYPE_INFO(0, event, IS_OBJECT, 0)
+PHP_PSR_END_ARG_INFO()
+
+PHP_PSR_BEGIN_ARG_WITH_RETURN_TYPE_INFO(PsrEventDispatcherListenerProviderInterface, getListenersForEvent, 1, IS_ITERABLE, 0)
+    ZEND_ARG_TYPE_INFO(0, event, IS_OBJECT, 0)
+PHP_PSR_END_ARG_INFO()
+
+PHP_PSR_BEGIN_ARG_WITH_RETURN_TYPE_INFO(PsrEventDispatcherStoppableEventInterface, isPropagationStopped, 0, _IS_BOOL, 0)
+PHP_PSR_END_ARG_INFO()
+#endif
+
+#endif /* PSR_EVENT_DISPATCHER_H */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: fdm=marker
+ * vim: et sw=4 ts=4
+ */

--- a/tests/PsrEventDispatcherEventDispatcherInterface.phpt
+++ b/tests/PsrEventDispatcherEventDispatcherInterface.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Psr\EventDispatcher\EventDispatcherInterface
+--SKIPIF--
+<?php include('skip_lt_php72.inc'); ?>
+--FILE--
+<?php
+include __DIR__ . '/SampleEventDispatcher.inc';
+var_dump(interface_exists('\\Psr\\EventDispatcher\\EventDispatcherInterface', false));
+var_dump(class_implements('SampleEventDispatcher', false));
+$dispatcher = new SampleEventDispatcher();
+var_dump($dispatcher instanceof SampleEventDispatcher);
+$event = new stdClass();
+$return = $dispatcher->dispatch($event);
+var_dump(is_object($return));
+--EXPECT--
+bool(true)
+array(1) {
+  ["Psr\EventDispatcher\EventDispatcherInterface"]=>
+  string(44) "Psr\EventDispatcher\EventDispatcherInterface"
+}
+bool(true)
+string(31) "SampleEventDispatcher::dispatch"
+bool(true)
+bool(true)

--- a/tests/PsrEventDispatcherListenerProviderInterface.phpt
+++ b/tests/PsrEventDispatcherListenerProviderInterface.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Psr\EventDispatcher\ListenerProviderInterface
+--SKIPIF--
+<?php include('skip_lt_php72.inc'); ?>
+--FILE--
+<?php
+include __DIR__ . '/SampleListenerProvider.inc';
+var_dump(interface_exists('\\Psr\\EventDispatcher\\ListenerProviderInterface', false));
+var_dump(class_implements('SampleListenerProvider', false));
+$provider = new SampleListenerProvider();
+var_dump($provider instanceof SampleListenerProvider);
+$event = new stdClass();
+$return = $provider->getListenersForEvent($event);
+var_dump(is_iterable($return));
+--EXPECT--
+bool(true)
+array(1) {
+  ["Psr\EventDispatcher\ListenerProviderInterface"]=>
+  string(45) "Psr\EventDispatcher\ListenerProviderInterface"
+}
+bool(true)
+string(44) "SampleListenerProvider::getListenersForEvent"
+bool(true)
+bool(true)

--- a/tests/PsrEventDispatcherStoppableEventInterface.phpt
+++ b/tests/PsrEventDispatcherStoppableEventInterface.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Psr\EventDispatcher\StoppableEventInterface
+--SKIPIF--
+<?php include('skip_lt_php72.inc'); ?>
+--FILE--
+<?php
+include __DIR__ . '/SampleStoppableEvent.inc';
+var_dump(interface_exists('\\Psr\\EventDispatcher\\StoppableEventInterface', false));
+var_dump(class_implements('SampleStoppableEvent', false));
+$event = new SampleStoppableEvent();
+var_dump($event instanceof SampleStoppableEvent);
+$return = $event->isPropagationStopped();
+var_dump(is_bool($return));
+--EXPECT--
+bool(true)
+array(1) {
+  ["Psr\EventDispatcher\StoppableEventInterface"]=>
+  string(43) "Psr\EventDispatcher\StoppableEventInterface"
+}
+bool(true)
+string(42) "SampleStoppableEvent::isPropagationStopped"
+bool(true)

--- a/tests/SampleEventDispatcher.inc
+++ b/tests/SampleEventDispatcher.inc
@@ -1,0 +1,13 @@
+<?php
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+class SampleEventDispatcher implements EventDispatcherInterface
+{
+    public function dispatch(object $event)
+    {
+        var_dump(__METHOD__, is_object($event));
+
+        return $event;
+    }
+}

--- a/tests/SampleListenerProvider.inc
+++ b/tests/SampleListenerProvider.inc
@@ -1,0 +1,13 @@
+<?php
+
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+class SampleListenerProvider implements ListenerProviderInterface
+{
+    public function getListenersForEvent(object $event): iterable
+    {
+        var_dump(__METHOD__, is_object($event));
+
+        return new ArrayIterator([]);
+    }
+}

--- a/tests/SampleStoppableEvent.inc
+++ b/tests/SampleStoppableEvent.inc
@@ -1,0 +1,13 @@
+<?php
+
+use Psr\EventDispatcher\StoppableEventInterface;
+
+class SampleStoppableEvent implements StoppableEventInterface
+{
+    public function isPropagationStopped(): bool
+    {
+        var_dump(__METHOD__);
+
+        return true;
+    }
+}

--- a/tests/phpinfo_lt_php72.phpt
+++ b/tests/phpinfo_lt_php72.phpt
@@ -1,7 +1,12 @@
 --TEST--
 psr phpinfo
 --SKIPIF--
-<?php include('skip_lt_php72.inc'); ?>
+<?php
+include('skip.inc');
+if (PHP_VERSION_ID >= 70200) {
+    print "skip Due to version incompatibility";
+}
+?>
 --FILE--
 <?php
 phpinfo(INFO_MODULES);
@@ -17,7 +22,6 @@ PSR-6 Cache Version => %d.%d.%d
 PSR-7 Http Message Version => %d.%d.%d
 PSR-11 Container Version => %d.%d.%d
 PSR-13 Link Version => %d.%d.%d
-PSR-14 Event Dispatcher => %d.%d.%d
 PSR-15 HTTP Handlers (Server Handler) => %d.%d.%d
 PSR-15 HTTP Handlers (Middleware) => %d.%d.%d
 PSR-16 Simple Cache Version => %d.%d.%d

--- a/tests/skip_lt_php72.inc
+++ b/tests/skip_lt_php72.inc
@@ -1,0 +1,5 @@
+<?php
+include 'skip.inc';
+if (PHP_VERSION_ID < 70200) {
+    print "skip Due to version incompatibility";
+}


### PR DESCRIPTION
Add [PSR-14: Event Dispatcher](http://www.php-fig.org/psr/psr-14) support.

PHP package: [psr/event-dispatcher](https://github.com/php-fig/event-dispatcher).

PSR-14 uses a new feature of PHP7.2: [object type](https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.object-type), so I skiped it when PHP version is less than 7.2.