### PR TITLE
Update SampleUploadedFileFactory.inc for PHP 8.4

### DIFF
--- a/tests/SampleUploadedFileFactory.inc
+++ b/tests/SampleUploadedFileFactory.inc
@@ -8,10 +8,10 @@ class SampleUploadedFileFactory implements UploadedFileFactoryInterface
 {
     public function createUploadedFile(
         StreamInterface $stream,
-        int $size = null,
+        ?int $size = null,
         int $error = \UPLOAD_ERR_OK,
-        string $clientFilename = null,
-        string $clientMediaType = null
+        ?string $clientFilename = null,
+        ?string $clientMediaType = null
     ): UploadedFileInterface
     {
         var_dump(__METHOD__, $stream, $size, $error, $clientFilename, $clientMediaType);


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types